### PR TITLE
Added ability to add files to pre-existing project

### DIFF
--- a/client/src/components/fileUpload.component.js
+++ b/client/src/components/fileUpload.component.js
@@ -43,14 +43,10 @@ function FileUpload(props){
                      outline: 'none'
                      }} {...getRootProps({className: 'dropzone'})}>
           <input {...getInputProps()} />
-          <p>Drag and drop the files relevant to your portfolio here.</p>
+          <p>Drag and drop the files relevant to your project here.</p>
           
         </div>
         <br/>
-        <aside>
-          <h4>Rejected files</h4>
-          <ul>{fileRejectionItems}</ul>
-        </aside>
       </>
     );
 }


### PR DESCRIPTION
Can now add files to a pre-existing project.

Todo, currently when the files get added, the page needs to be refreshed in order to use them in the front-end. One way around this, after adding the files, is to redo the get request to resync the files variable in the context. This is slightly inefficient, but less bug prone (and we can refactor if we have time).