### PR TITLE
Can now view others profiles

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 const app = require('express')();
 const { createPost, getAllPosts } = require('./routes/Posts');
-const {signup, login, uploadImage, updateProfilePic, addUserDetails, getAuthorisedUser} = require('./routes/user');
-const { getAboutMe, createAboutMe, createUserInfo, getUserInfo, getUserTags, createUserTags } = require("./routes/aboutMe");
+const {signup, login, uploadImage, addUserDetails, getAuthorisedUser} = require('./routes/user');
+const { getAboutMe, createAboutMe, createUserInfo, getUserInfo, updateProfilePic, getProfilePic, getUserTags, createUserTags } = require("./routes/aboutMe");
 const { viewUser } = require("./routes/viewUser");
 
 const { saveProject, getProjects, getProjectInfo, getAllProjectCards, addProjectCard, deleteProjectCard, editFileCardAssociation, addFile, getProjectFiles } = require("./routes/projects");
@@ -22,16 +22,18 @@ app.post('/createPost',userAuth,createPost);
 app.post('/signup',signup);
 app.post('/login', login)
 app.post('/user/image',uploadImage)
-app.post('/user/updatepp',userAuth, updateProfilePic)
 app.post('/user',userAuth, addUserDetails)
 app.get('/user',userAuth,getAuthorisedUser)
 
+// Routes for setting and getting profile content
 app.post("/aboutme", userAuth, createAboutMe);
-app.get("/aboutme", userAuth, getAboutMe);
+app.post("/getaboutme", getAboutMe);
 app.post("/userinfo", userAuth, createUserInfo);
-app.get("/userinfo", userAuth, getUserInfo);
+app.post("/getuserinfo", getUserInfo);
+app.post('/updatedp',userAuth, updateProfilePic)
+app.post('/getdp', getProfilePic)
 app.post("/tags", userAuth, createUserTags);
-app.get("/tags", userAuth, getUserTags);
+app.post("/gettags", getUserTags);
 
 app.post("/saveproject", userAuth, saveProject)
 app.get("/projects", userAuth, getProjects);

--- a/api/routes/aboutMe.js
+++ b/api/routes/aboutMe.js
@@ -20,13 +20,13 @@ exports.createAboutMe = (req, res) => {
 
 exports.getAboutMe = (req,res) => {
     let aboutMe = {};
-    db.doc(`/users/${req.user.handle}/data/aboutme`).get().then(doc => {
+    db.doc(`/users/${req.body.handle}/data/aboutme`).get().then(doc => {
         if(doc.exists){
             aboutMe = doc.data().aboutMe;
             return res.status(200).json({aboutMe});
         } else {
             aboutMe = { displayName : "Display name", description : "Profile description"};
-            db.doc(`/users/${req.user.handle}/data/aboutme`).set({aboutMe})
+            db.doc(`/users/${req.body.handle}/data/aboutme`).set({aboutMe})
             return res.status(200).json({aboutMe});
         }
     }).catch(err => {
@@ -57,14 +57,39 @@ exports.createUserInfo = (req, res) => {
 
 exports.getUserInfo = (req,res) => {
     let userInfo = {};
-    db.doc(`/users/${req.user.handle}/data/userinfo`).get().then(doc => {
+    db.doc(`/users/${req.body.handle}/data/userinfo`).get().then(doc => {
         if(doc.exists){
             userInfo = doc.data().userInfo;
             return res.status(200).json({userInfo});
         } else {
             userInfo = { occupation : "Occupation", location : "Location", number : "Phone number", email : "Contact email" };
-            db.doc(`/users/${req.user.handle}/data/userInfo`).set({userInfo})
+            db.doc(`/users/${req.body.handle}/data/userinfo`).set({userInfo})
             return res.status(200).json({userInfo});
+        }
+    }).catch(err => {
+        console.error(err);
+        return res.status(500).json({error:err.code})
+    })
+}
+
+exports.updateProfilePic  = (req,res) => {
+    let url = Object.keys(req.body)[0] + '=media';
+    console.log(url);
+    db.doc(`/users/${req.user.handle}`).update({"imageUrl": url}).then(() => {
+        return res.status(201).json({message: 'Success'})
+    }).catch( err => {
+        console.error(err)
+        return res.status(400).json({error:err.code})
+    })
+}
+
+exports.getProfilePic = (req,res) => {
+    let profilePic = {};
+
+    db.doc(`/users/${req.body.handle}`).get().then(doc => {
+        if(doc.exists){
+            profilePic = doc.data().imageUrl;
+            return res.status(200).json({profilePic});
         }
     }).catch(err => {
         console.error(err);
@@ -88,7 +113,7 @@ exports.createUserTags = (req, res) => {
 
 exports.getUserTags = (req,res) => {
     let tags = [];
-    db.doc(`/users/${req.user.handle}/data/tags`).get().then(doc => {
+    db.doc(`/users/${req.body.handle}/data/tags`).get().then(doc => {
         if(doc.exists){
             tags = doc.data().tags;
         }

--- a/api/routes/user.js
+++ b/api/routes/user.js
@@ -137,18 +137,6 @@ exports.addUserDetails  = (req,res) => {
         })
 }
 
-exports.updateProfilePic  = (req,res) => {
-    let url = Object.keys(req.body)[0] + '=media';
-    console.log(url);
-    db.doc(`/users/${req.user.handle}`).update({"imageUrl": url}).then(() => {
-        return res.status(201).json({message: 'Success'})
-    }).catch( err => {
-        console.error(err)
-        return res.status(400).json({error:err.code})
-    })
-
-}
-
 exports.getAuthorisedUser = (req,res) => {
     let userData = {};
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -77,7 +77,7 @@ class App extends Component {
           <Route 
             path = "/:handle" 
             render = {(props) => (
-              <AboutThem {...props}/>
+              <MyProfile {...props}/>
             )}
           />   
         </Switch>

--- a/client/src/components/login.component.js
+++ b/client/src/components/login.component.js
@@ -4,6 +4,7 @@ import Input from "react-validation/build/input";
 import CheckButton from "react-validation/build/button";
 
 import AuthService from "../services/auth.service";
+import UserService from "../services/user.service";
 
 const required = (value) => {
   if (!value) {
@@ -45,8 +46,12 @@ const Login = (props) => {
     if (checkBtn.current.context._errors.length === 0) {
       AuthService.login(email, password).then(
         () => {
-          props.history.push("/profile");
-          window.location.reload();
+          UserService.getMe().then(
+            (me) => {
+              props.history.push("/" + me.handle);
+              window.location.reload();
+            }
+          )
         },
         (error) => {
           const resMessage =

--- a/client/src/components/myProfile.component.js
+++ b/client/src/components/myProfile.component.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect }from 'react';
 //import { Grid, Nav, NavDropdown } from 'react-bootstrap';
 import './myprofile.component.css';
 import img from './random.jpg';
@@ -11,27 +11,39 @@ import Projects from "./profileComponents/projects.component";
 import Tags from "./profileComponents/tags.component";
 import Tabs from "../components/tabs.component";
 import FindUser from "./profileComponents/findUser.component";
+import UserService from "../services/user.service"
 
 import ProjectPanel from "../cardComponents/projectPanel.component"
-export default class MyProfile extends React.Component {
+export default function MyProfile (props) {
+    
+        const profileHandle = props.location.pathname.split("/")[1]
+        const [authorised, setAuthorised] = useState(false);
 
-    render() {
+        useEffect( () => {
+            UserService.isUser(profileHandle).then(
+                (res) => {
+                    setAuthorised(res);
+                    console.log(res);
+                }
+              )
+        }, []);
+
         return (
         <div>
             <div class="profile">
                 <div class="profile_left">
                     <div class="img_here">
-                        <DP/>
+                        <DP authorised={authorised} profileHandle={profileHandle}/>
                     </div>
                     <div class="profile_content">
                         <div class="profile_item profile_info">
-                            <UserInfo/>
+                            <UserInfo authorised={authorised} profileHandle={profileHandle}/>
                         </div>
                         <div class="profile_item profile_skills">
                             <div class="title">
                                 <p class="bold">skills</p>
                                 <div>
-                                    <Tags/>
+                                    <Tags authorised={authorised} profileHandle={profileHandle}/>
                                 </div>
                             </div>
                         </div>
@@ -39,7 +51,7 @@ export default class MyProfile extends React.Component {
                 </div>
                 <div class="profile_right">
                     <div class="profile_item profile_about">
-                        <AboutMe/>
+                        <AboutMe authorised={authorised} profileHandle={profileHandle}/>
                     </div>
                     <div class="profile_item profile_work">
                         <div class="title">
@@ -96,7 +108,7 @@ export default class MyProfile extends React.Component {
         </div>
 
         )
-    }
+    
 }
 
 

--- a/client/src/components/profileComponents/aboutMe.component.js
+++ b/client/src/components/profileComponents/aboutMe.component.js
@@ -12,29 +12,36 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 
 import authHeader from "../../services/auth-header";
 
-
 const API_URL = "http://localhost:5000/eportfolio-4760f/us-central1/api";
 
-const AboutMe = () => {
+const AboutMe = (props) => {
 
     const [loading, setLoading] = useState(false);
+    const [authorised, setAuthorised] = useState(props.authorised);
     const [open, setOpen] = useState(false);
     const [aboutMe, setAboutMe] = useState("");
     const [updatedAboutMe, setUpdatedAboutMe] = useState("");
 
     useEffect( () => {
-        setLoading(true);
-        axios.get(API_URL + "/aboutme", { headers: authHeader() })
-            .then( res => {
-                console.log(res);
-                setAboutMe(res.data.aboutMe);
-                setUpdatedAboutMe(res.data.aboutMe);
-                setLoading(false);
-            })
-            .catch( err => {
-                console.log(err);
-            })
-    }, []);
+        setAuthorised(props.authorised);
+
+        if(!aboutMe){
+            setLoading(true);
+
+            axios.post(API_URL + "/getaboutme", {handle : props.profileHandle})
+                .then( res => {
+                    console.log(res);
+                    setAboutMe(res.data.aboutMe);
+                    setUpdatedAboutMe(res.data.aboutMe);
+                    setLoading(false);
+                })
+                .catch( err => {
+                    console.log(err);
+                    setLoading(false);
+                })
+        }
+
+    }, [props]);
     
     const handleClickOpen = () => {
         setOpen(true);
@@ -56,6 +63,17 @@ const AboutMe = () => {
         setUpdatedAboutMe({...updatedAboutMe, description: e.target.value});
     }
 
+    // This function handles the case for freshly registered users, whose content is set to the default...
+    // which acts as a placeholder on the page. This default placeholder is clunky to act as a defaultValue...
+    // in the input fields
+    const getDefaultVals = (vals) => {
+        let defaultVals = Object.assign({}, vals);
+        
+        if (defaultVals.displayName == "Display name"){ defaultVals.displayName = ""; }
+        if (defaultVals.description == "Profile description"){ defaultVals.description = ""; }
+        
+        return defaultVals;
+    }
 
     const onSubmit = (e) => {
         e.preventDefault(); // allows us override the default html stuff
@@ -69,33 +87,35 @@ const AboutMe = () => {
     }
     
     return (
-            <div>
+        <div>
             {loading ? <span className="spinner-border spinner-border-sm"></span> : 
             <>
-            <CardContent>
-                <Typography variant="h3" component="p">{aboutMe.displayName}</Typography>
-                    <Typography variant="h4" color="textSecondary" component="p">{aboutMe.description}</Typography>
-            </CardContent>
-            <IconButton> <Edit onClick={handleClickOpen} /> </IconButton>
-            <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
-                    <DialogTitle id="form-dialog-title">Edit about me</DialogTitle>
-                    <DialogContent>
-                        <FormControl>
-                            <InputLabel htmlFor="component-helper">Display Name</InputLabel>
-                            <Input onChange={onChangeDisplayName} value={aboutMe.displayName}/></FormControl>
-                        <FormControl>
-                            <InputLabel htmlFor="component-helper">Profile description</InputLabel>
-                            <Input onChange={onChangeDescription} value={aboutMe.description}/></FormControl>
-                    </DialogContent>
-                    <DialogActions>
-                        <Button onClick={handleCancel} color="primary">
-                            Cancel
-                        </Button>
-                        <Button onClick={onSubmit} color="primary">
-                            Confirm
-                        </Button>
-                    </DialogActions>
-                </Dialog>        
+                <CardContent>
+                    <Typography variant="h3" component="p">{aboutMe.displayName}</Typography>
+                        <Typography variant="h4" color="textSecondary" component="p">{aboutMe.description}</Typography>
+                </CardContent>
+                {authorised ? (<>
+                    <IconButton> <Edit onClick={handleClickOpen} /> </IconButton>
+                    <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+                            <DialogTitle id="form-dialog-title">Edit about me</DialogTitle>
+                            <DialogContent>
+                                <FormControl>
+                                    <InputLabel htmlFor="component-helper">Display name</InputLabel>
+                                    <Input onChange={onChangeDisplayName} defaultValue={getDefaultVals(aboutMe).displayName}/></FormControl>
+                                <FormControl>
+                                    <InputLabel htmlFor="component-helper">Profile description</InputLabel>
+                                    <Input onChange={onChangeDescription} defaultValue={getDefaultVals(aboutMe).description}/></FormControl>
+                            </DialogContent>
+                            <DialogActions>
+                                <Button onClick={handleCancel} color="primary">
+                                    Cancel
+                                </Button>
+                                <Button onClick={onSubmit} color="primary">
+                                    Confirm
+                                </Button>
+                            </DialogActions>
+                        </Dialog>
+                </>) : (<></>)}
             </>
             }
         </div>

--- a/client/src/components/profileComponents/dp.component.js
+++ b/client/src/components/profileComponents/dp.component.js
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import Axios from "axios";
-
-import UserService from "../../services/user.service";
+import axios from "axios";
 
 import {makeStyles, ButtonBase, Tooltip } from '@material-ui/core';
+
+import authHeader from "../../services/auth-header";
+
+const API_URL = "http://localhost:5000/eportfolio-4760f/us-central1/api";
 
 const useStyles = makeStyles({
     input: {
@@ -21,21 +23,33 @@ const useStyles = makeStyles({
     },
 });
 
-const DP = () => {
-
+const DP = (props) => {
+    
     const [loading, setLoading] = useState(false);
+    const [authorised, setAuthorised] = useState(props.authorised);
     const [DP, setDP] = useState("");
     const classes = useStyles();
     
     useEffect(() => {
-        setLoading(true)
-        UserService.getMe().then(
-            (me) => {
-                setDP(me.imageUrl);
+        setAuthorised(props.authorised);
+
+        if(!DP){
+            setLoading(true);
+
+            axios.post(API_URL + "/getdp", {handle : props.profileHandle}).then(
+                (res) => {
+                    console.log(res);
+                    setDP(res.data.profilePic);
+                    setLoading(false);
+                }
+            )
+            .catch( err => {
+                console.log(err);
                 setLoading(false);
-            }
-        )
-    }, []);
+            })
+        }
+        
+    }, [props]);
 
     const onChange = (e) => {
         e.preventDefault();
@@ -45,34 +59,36 @@ const DP = () => {
         formData.append("file", image, image.name);
         
         setLoading(true);
-        Axios.post(
-          "http://localhost:5000/eportfolio-4760f/us-central1/api/user/image",
-          formData
-        )
-          .then((res) => {
-            UserService.updateProfilePic(res.data.image);
-            setDP(res.data.image);
-            setLoading(false);
-          })
-          .catch((err) => {
+        axios.post(API_URL + "/user/image", formData).then(
+            (res) => {
+                let req = res.data.image
+                axios.post(API_URL + "/updatedp", req, { headers: authHeader() });
+                setDP(res.data.image);
+                setLoading(false);
+            })
+        .catch((err) => {
             console.error(err);
-          });
+        });
           
       }
 
     return (
         <div>
             {loading ? <span className="spinner-border spinner-border-sm"></span> :
-            <>
-                <input className={classes.input} ccept="image/*" id="icon-button-file" type="file" onChange={onChange}/>
-                <label htmlFor="icon-button-file">
-                    <Tooltip title="Change profile picture">
-                    <ButtonBase className={classes.image} color="primary" aria-label="upload picture" component="span">
-                        <img className={classes.img} src={DP} />
-                    </ButtonBase> 
-                    </Tooltip>
-                </label>
-            </>
+                <>
+                {authorised ? (
+                    <>
+                    <input className={classes.input} ccept="image/*" id="icon-button-file" type="file" onChange={onChange}/>
+                    <label htmlFor="icon-button-file">
+                        <Tooltip title="Change profile picture">
+                        <ButtonBase className={classes.image} color="primary" aria-label="upload picture" component="span">
+                            <img className={classes.img} src={DP} />
+                        </ButtonBase> 
+                        </Tooltip>
+                    </label>
+                    </>
+                ) : (<img className={classes.img} src={DP} />)}
+                </>
             }
         </div>
     );

--- a/client/src/components/profileComponents/tags.component.js
+++ b/client/src/components/profileComponents/tags.component.js
@@ -9,21 +9,34 @@ import authHeader from "../../services/auth-header";
 const API_URL = "http://localhost:5000/eportfolio-4760f/us-central1/api";
 
 
-const Tags = () => {
+const Tags = (props) => {
 
-  const [ tags, setTags ] = useState([]);
-
+  const [tags, setTags] = useState([]);
   const [tagInput, setTagInput] = useState("");
 
+  const [authorised, setAuthorised] = useState(props.authorised);
+  const [loading, setLoading] = useState(false);
+
   useEffect( () => {
-    axios.get(API_URL + "/tags", { headers: authHeader() })
-        .then( res => {
-            setTags(tags => tags.concat(res.data.tags));
-        })
-        .catch( err => {
-            console.log(err);
-        })
-  }, []);
+
+    setAuthorised(props.authorised);
+
+    // Only want to request data if it hasn't been loaded
+    if(tags.length == 0){
+      setLoading(true);
+
+      axios.post(API_URL + "/gettags", {handle : props.profileHandle})
+      .then( res => {
+          setTags(tags => tags.concat(res.data.tags));
+          setLoading(false);
+      })
+      .catch( err => {
+          console.log(err);
+          setLoading(false);
+      })
+    }
+
+  }, [props]);
 
   
   const removeTag = (i) => {
@@ -61,18 +74,28 @@ const Tags = () => {
   }
 
   return (
-    <div className="input-tag">
-      <ul className="input-tag__tags">
-        { tags.map((tag, i) => (
-          <li key={tag}>
-            {tag}
-            <button type="button" onClick={() => { removeTag(i); }}>+</button>
-          </li>
-        ))}
-        <li className="input-tag__tags__input">
-          <Input value={tagInput} onChange={onChangeTag} onKeyDown={inputKeyDown}/>   
-        </li>
-      </ul>
+    <div>
+      {loading ? <span className="spinner-border spinner-border-sm"></span> : 
+      <>
+        <div className="input-tag">
+          <ul className="input-tag__tags">
+            { tags.map((tag, i) => (
+              <li key={tag}>
+                {tag}
+                {authorised ? (<>
+                  <button type="button" onClick={() => { removeTag(i); }}>+</button>
+                </>) : (<></>)}
+              </li>
+            ))}
+            {authorised ? (<>
+              <li className="input-tag__tags__input">
+                <Input value={tagInput} onChange={onChangeTag} onKeyDown={inputKeyDown}/>   
+              </li>
+            </>) : (<></>)}
+          </ul>
+        </div>
+      </>
+      }
     </div>
   );
 }

--- a/client/src/components/profileComponents/userInfo.component.js
+++ b/client/src/components/profileComponents/userInfo.component.js
@@ -28,28 +28,36 @@ const useStyles = makeStyles({
       }
 });
 
-const UserInfo = () => {
+const UserInfo = (props) => {
 
     const classes = useStyles();
 
     const [loading, setLoading] = useState(false);
+    const [authorised, setAuthorised] = useState(props.authorised);
     const [open, setOpen] = useState(false);
     const [userInfo, setUserInfo] = useState("");
     const [updatedUserInfo, setUpdatedUserInfo] = useState("");
 
     useEffect( () => {
-        setLoading(true);
-        axios.get(API_URL + "/userinfo", { headers: authHeader() })
-            .then( res => {
-                console.log(res);
-                setUserInfo(res.data.userInfo);
-                setUpdatedUserInfo(res.data.userInfo);
-                setLoading(false);
-            })
-            .catch( err => {
-                console.log(err);
-            })
-    }, []);
+        setAuthorised(props.authorised);
+
+        if(!userInfo){
+            setLoading(true);
+
+            axios.post(API_URL + "/getuserinfo", {handle : props.profileHandle})
+                .then( res => {
+                    console.log(res);
+                    setUserInfo(res.data.userInfo);
+                    setUpdatedUserInfo(res.data.userInfo);
+                    setLoading(false);
+                })
+                .catch( err => {
+                    console.log(err);
+                    setLoading(false);
+                })
+        } 
+
+    }, [props]);
     
     const handleClickOpen = () => {
         setOpen(true);
@@ -77,6 +85,19 @@ const UserInfo = () => {
         setUpdatedUserInfo({...updatedUserInfo, email: e.target.value});
     }
 
+    // This function handles the case for freshly registered users, whose content is set to the default...
+    // which acts as a placeholder on the page. This default placeholder is clunky to act as a defaultValue...
+    // in the input fields
+    const getDefaultVals = (vals) => {
+        let defaultVals = Object.assign({}, vals);
+        
+        if (defaultVals.occupation == "Occupation"){ defaultVals.occupation = ""; }
+        if (defaultVals.location == "Location"){ defaultVals.location = ""; }
+        if (defaultVals.number == "Phone number"){ defaultVals.number = ""; }
+        if (defaultVals.email == "Contact email"){ defaultVals.email = ""; }
+
+        return defaultVals;
+    }
 
     const onSubmit = (e) => {
         e.preventDefault(); // allows us override the default html stuff
@@ -90,43 +111,45 @@ const UserInfo = () => {
     }
     
     return (
-            <div>
+        <div>
             {loading ? <span className="spinner-border spinner-border-sm"></span> : 
             <>
-            <Card>
-            <CardContent>
-                    <Typography className={classes.typography} color="textSecondary" component="p">{userInfo.occupation}</Typography>
-                    <Typography className={classes.typography} color="textSecondary" component="p">{userInfo.location}</Typography>
-                    <Typography className={classes.typography} color="textSecondary" component="p">{userInfo.number}</Typography>
-                    <Typography className={classes.typography} color="textSecondary" component="p">{userInfo.email}</Typography>
-            </CardContent>
-            </Card>
-            <IconButton> <Edit onClick={handleClickOpen} /> </IconButton>
-            <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
-                    <DialogTitle id="form-dialog-title">Edit details</DialogTitle>
-                    <DialogContent className={classes.marginAutoItem}>
-                        <FormControl className={classes.alignItemsAndJustifyContent}>
-                            <InputLabel htmlFor="component-helper">Occupation</InputLabel>
-                            <Input onChange={onChangeOccupation} value={userInfo.occupation}/></FormControl>
-                        <FormControl className={classes.alignItemsAndJustifyContent}>
-                            <InputLabel htmlFor="component-helper">Location</InputLabel>
-                            <Input onChange={onChangeLocation} value={userInfo.location}/></FormControl>
-                        <FormControl className={classes.alignItemsAndJustifyContent}>
-                            <InputLabel htmlFor="component-helper">Contact number</InputLabel>
-                            <Input onChange={onChangeNumber} value={userInfo.number}/></FormControl>
-                        <FormControl className={classes.alignItemsAndJustifyContent}>
-                            <InputLabel htmlFor="component-helper">Contact email address</InputLabel>
-                            <Input onChange={onChangeEmail} value={userInfo.email}/></FormControl>    
-                    </DialogContent>
-                    <DialogActions>
-                        <Button onClick={handleCancel} color="primary">
-                            Cancel
-                        </Button>
-                        <Button onClick={onSubmit} color="primary">
-                            Confirm
-                        </Button>
-                    </DialogActions>
-                </Dialog>        
+                <Card>
+                <CardContent>
+                        <Typography className={classes.typography} color="textSecondary" component="p">{userInfo.occupation}</Typography>
+                        <Typography className={classes.typography} color="textSecondary" component="p">{userInfo.location}</Typography>
+                        <Typography className={classes.typography} color="textSecondary" component="p">{userInfo.number}</Typography>
+                        <Typography className={classes.typography} color="textSecondary" component="p">{userInfo.email}</Typography>
+                </CardContent>
+                </Card>
+                {authorised ? (<>
+                    <IconButton> <Edit onClick={handleClickOpen} /> </IconButton>
+                    <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+                        <DialogTitle id="form-dialog-title">Edit details</DialogTitle>
+                        <DialogContent className={classes.marginAutoItem}>
+                            <FormControl className={classes.alignItemsAndJustifyContent}>
+                                <InputLabel htmlFor="component-helper">Occupation</InputLabel>
+                                <Input onChange={onChangeOccupation} defaultValue={getDefaultVals(userInfo).occupation}/></FormControl>
+                            <FormControl className={classes.alignItemsAndJustifyContent}>
+                                <InputLabel htmlFor="component-helper">Location</InputLabel>
+                                <Input onChange={onChangeLocation} defaultValue={getDefaultVals(userInfo).location}/></FormControl>
+                            <FormControl className={classes.alignItemsAndJustifyContent}>
+                                <InputLabel htmlFor="component-helper">Contact number</InputLabel>
+                                <Input onChange={onChangeNumber} defaultValue={getDefaultVals(userInfo).number}/></FormControl>
+                            <FormControl className={classes.alignItemsAndJustifyContent}>
+                                <InputLabel htmlFor="component-helper">Contact email address</InputLabel>
+                                <Input onChange={onChangeEmail} defaultValue={getDefaultVals(userInfo).email}/></FormControl>
+                        </DialogContent>
+                        <DialogActions>
+                            <Button onClick={handleCancel} color="primary">
+                                Cancel
+                            </Button>
+                            <Button onClick={onSubmit} color="primary">
+                                Confirm
+                            </Button>
+                        </DialogActions>       
+                    </Dialog>
+                </>) : (<></>)}
             </>
             }
         </div>

--- a/client/src/components/registration.component.js
+++ b/client/src/components/registration.component.js
@@ -57,7 +57,7 @@ const Register = (props) => {
     if (checkBtn.current.context._errors.length === 0) {
       AuthService.register(email, password, cPassword, handle).then(
         () => {
-          props.history.push("/profile");
+          props.history.push("/" + handle);
           window.location.reload();
         },
         (error) => {

--- a/client/src/services/user.service.js
+++ b/client/src/services/user.service.js
@@ -16,17 +16,16 @@ async function getMe() {
   
 };
 
-async function updateProfilePic(req) {
-  let response = await axios.post(API_URL + "/user/updatepp", req, { headers: authHeader() })
-    
-  if (response.data.userData) {
-    console.log(response.data.userData.credentials);
-  }
+async function isUser(checkHandle) {
+  let response = await axios.get(API_URL + "/user", { headers: authHeader() })
   
-};
-
+  console.log(response.data.userData.credentials.handle == checkHandle);
+  
+  return (response.data.userData.credentials.handle == checkHandle);
+  
+}
 
 export default {
   getMe,
-  updateProfilePic,
+  isUser,
 };


### PR DESCRIPTION
- Can now type /`handle` and be taken to a users profile page.
- If you are logged in as the /`handle` you are given the option to edit the page
- To handle this backend routes for getting the data do not require auth, however to change data users will still need the right authorisation
- Also worth noting that those changed routes now become post routes with a new name, this is because the requests include a handle in the body saying who they want to get and axios can't handle sending a GET with a body
- Next: Give users option to make their profile private, which in that case typing in their /'handle' should show nothing and they also shouldn't show up in /profilespage