### PR TITLE
Bugfix, Dialog variables cleared after adding card

### DIFF
--- a/client/src/cardComponents/DialogPortfolioCard.component.js
+++ b/client/src/cardComponents/DialogPortfolioCard.component.js
@@ -102,7 +102,13 @@ function DialogPortfolioCard(props){
           <Button onClick={handleCancelClick} color="primary">
             Cancel
           </Button>
-          <Button onClick={() => handleDialogConfirm(formTitle, formSubtitle, formDescription, filesToAssociate, currentDisplayPicture)} color="primary">
+          <Button onClick={() => {
+              handleDialogConfirm(formTitle, formSubtitle, formDescription, filesToAssociate, currentDisplayPicture);
+              setFormTitle("");
+              setFormSubtitle("");
+              setFormDescription("");
+            }} 
+            color="primary">
             Confirm
           </Button>
           


### PR DESCRIPTION
After adding a card to the portfolio, when the user wants to add another card, the Dialog fields will be cleared (intended behaviour) as opposed to containing the fields from the card they previously added (old behaviour).